### PR TITLE
Add "mainscene" and "map" commands

### DIFF
--- a/addons/gsom_console/gsom_console_autoload.gd
+++ b/addons/gsom_console/gsom_console_autoload.gd
@@ -73,16 +73,19 @@ var _help_color_idx: int = 0
 func _ready() -> void:
 	register_cmd("help", "Display available commands and variables.")
 	register_cmd("quit", "Close the application, exit to desktop.")
-	register_cmd("disconnect", "Quit the current map and return to the main menu.")
+	register_cmd("mainmenu", "Quit the current map and return to the main menu.")
+	register_cmd("map", "Load a specific map")
 	called_cmd.connect(
 		func (cmd_name: String, args: PackedStringArray) -> void:
 			if cmd_name == "help":
 				_help(args)
 			elif cmd_name == "quit":
 				get_tree().quit()
-			elif cmd_name == "disconnect":
-				get_tree().change_scene_to_file("application/run/main_scene")
-	)
+			elif cmd_name == "mainmenu":
+				get_tree().change_scene_to_file(
+					ProjectSettings.get_setting("application/run/main_scene")
+				)
+				GsomConsole.toggle()
 	
 	self.log(
 		"Type `%s` to view existing commands and variables." % [

--- a/addons/gsom_console/gsom_console_autoload.gd
+++ b/addons/gsom_console/gsom_console_autoload.gd
@@ -73,12 +73,15 @@ var _help_color_idx: int = 0
 func _ready() -> void:
 	register_cmd("help", "Display available commands and variables.")
 	register_cmd("quit", "Close the application, exit to desktop.")
+	register_cmd("disconnect", "Quit the current map and return to the main menu.")
 	called_cmd.connect(
 		func (cmd_name: String, args: PackedStringArray) -> void:
 			if cmd_name == "help":
 				_help(args)
 			elif cmd_name == "quit":
 				get_tree().quit()
+			elif cmd_name == "disconnect":
+				get_tree().change_scene_to_file("application/run/main_scene")
 	)
 	
 	self.log(


### PR DESCRIPTION
added a basic command that exits the player to whatever is set as the game's default scene. In my case this is the main menu because I originally wrote this for my own game and i thought it would be a good addition to the main branch. One thing i could probably add once i have a bit more time is an export var that actually lets the user select what map the disconnect command loads.

I'll probably write a better system for this down the road but ive been spending the past little while porting useful source commands for debugging and the like so ill be sure to port those over if you want :)
